### PR TITLE
Removed SharpYaml dependency and added MergingParser.

### DIFF
--- a/src/Yarm.Converters/StringExtensions.cs
+++ b/src/Yarm.Converters/StringExtensions.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Dynamic;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-
+using System;
+using System.Dynamic;
+using System.IO;
+using YamlDotNet.Core;
 using YamlDotNet.Serialization;
-
-using Serializer = SharpYaml.Serialization.Serializer;
 
 namespace Yarm.Converters
 {
@@ -56,18 +54,19 @@ namespace Yarm.Converters
                 return null;
             }
 
-            object deserialised;
+            object deserialized;
             try
             {
-                deserialised = new Serializer().Deserialize(yaml);
+                var reader = new MergingParser(new Parser(new StringReader(yaml)));
+
+                deserialized = new Deserializer().Deserialize(reader);
             }
             catch (Exception ex)
             {
                 throw new InvalidYamlException(ex.Message);
             }
 
-            var json = JsonConvert.SerializeObject(deserialised, Formatting.Indented);
-
+            var json = JsonConvert.SerializeObject(deserialized, Formatting.Indented);
             return json;
         }
     }

--- a/src/Yarm.Converters/Yarm.Converters.csproj
+++ b/src/Yarm.Converters/Yarm.Converters.csproj
@@ -32,7 +32,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpYaml" Version="1.6.4" />
     <PackageReference Include="YamlDotNet" Version="5.0.1" />
   </ItemGroup>
 

--- a/test/Yarm.Converters.Tests/StringExtensionsTests.cs
+++ b/test/Yarm.Converters.Tests/StringExtensionsTests.cs
@@ -1,14 +1,11 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-
-using FluentAssertions;
-
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Yarm.Converters.Tests
 {
@@ -136,6 +133,28 @@ namespace Yarm.Converters.Tests
             dic[key2].Value<int>().Should().Be(value2);
             dic[key3].Value<bool>().Should().Be(value3);
             dic[key4].Values<string>().Should().BeEquivalentTo(value41, value42);
+        }
+
+        [TestMethod]
+        public void Given_Yaml_With_Merge_ToJson_ShouldReturn_Result()
+        {
+            var yaml = @"
+anchor: &default
+  key1: value1
+  key2: value2
+alias:
+  <<: *default
+  key2: Overriding key2
+  key3: value3
+";
+
+
+            var result = StringExtensions.ToJson(yaml);
+
+            var dic = JsonConvert.DeserializeObject<JObject>(result);
+            dic["alias"]["key1"].Value<string>().Should().Be("value1");
+            dic["alias"]["key2"].Value<string>().Should().Be("Overriding key2");
+            dic["alias"]["key3"].Value<string>().Should().Be("value3");
         }
     }
 }


### PR DESCRIPTION
### Removed SharpYaml dependency and added MergingParser.

I don't think SharpYaml was used for anything, unless it was giving some important default values. 

I added MergingParser, to support merging.

Now it should be possible to do this:

```
Put_Message: &putMessage
          type: Http
          inputs:
            method: post
            uri: "https://@{triggerBody()['storageAccount']}.queue.core.windows.net/@{triggerBody()['queueName']}/messages"
            authentication:
              type: ManagedServiceIdentity
              audience: https://storage.azure.com/
            body: "<QueueMessage><MessageText>@{triggerBody()['message']}</MessageText></QueueMessage>"
            headers:
              x-ms-version: 2018-03-28
          runAfter: {}
Put_Message_2:
          <<: *putMessage
          runAfter:
            Put_Message:
              - Succeeded
```

Notice, the Put_Message_2 uses all the properties from first action, but overrides RunAfter. 
Without the MergingParser, the overriding wouldn't be possible, it would be all or nothing.

I consider this to be an useful and common scenario in the arm templates.


